### PR TITLE
Fix misconception around intent of required flag

### DIFF
--- a/src/generators/prop_types/utilities/toPropTypes.js
+++ b/src/generators/prop_types/utilities/toPropTypes.js
@@ -10,9 +10,9 @@ function toPropTypes(entity, required = false) {
   let propType;
 
   if (entity.isMap) {
-    propType = `PropTypes.objectOf(${toPropTypes(entity.nestedEntity, required)})`;
+    propType = `PropTypes.objectOf(${toPropTypes(entity.nestedEntity)})`;
   } else if (entity.isArray) {
-    propType = `PropTypes.arrayOf(${toPropTypes(entity.nestedEntity, required)})`;
+    propType = `PropTypes.arrayOf(${toPropTypes(entity.nestedEntity)})`;
   } else if (entity.isPrimitive) {
     propType = toPrimitivePropTypes(entity);
   } else if (entity.isModel) {

--- a/test/specs/generators/prop_types/utilities/toPropType.spec.js
+++ b/test/specs/generators/prop_types/utilities/toPropType.spec.js
@@ -54,10 +54,10 @@ describe('toPropTypes', () => {
 
   test('should convert required apibuilder types to prop types', () => {
     expect(toPropTypes(Entity.fromType('string', service), true)).toEqual('PropTypes.string.isRequired');
-    expect(toPropTypes(Entity.fromType('[string]', service), true)).toEqual('PropTypes.arrayOf(PropTypes.string.isRequired).isRequired');
-    expect(toPropTypes(Entity.fromType('[[string]]', service), true)).toEqual('PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string.isRequired).isRequired).isRequired');
-    expect(toPropTypes(Entity.fromType('map[string]', service), true)).toEqual('PropTypes.objectOf(PropTypes.string.isRequired).isRequired');
-    expect(toPropTypes(Entity.fromType('map[[string]]', service), true)).toEqual('PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string.isRequired).isRequired).isRequired');
+    expect(toPropTypes(Entity.fromType('[string]', service), true)).toEqual('PropTypes.arrayOf(PropTypes.string).isRequired');
+    expect(toPropTypes(Entity.fromType('[[string]]', service), true)).toEqual('PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired');
+    expect(toPropTypes(Entity.fromType('map[string]', service), true)).toEqual('PropTypes.objectOf(PropTypes.string).isRequired');
+    expect(toPropTypes(Entity.fromType('map[[string]]', service), true)).toEqual('PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)).isRequired');
   });
 
   test('should throw when type is not available in service', () => {


### PR DESCRIPTION
It turns out the `required` flag in fields is intended for the containing type (e.g. map or array) and not the nested type. 