### PR TITLE
Use strings for field keys to prevent invalid key errors

### DIFF
--- a/src/generators/prop_types/generators/generator-model/templates/model.ejs
+++ b/src/generators/prop_types/generators/generator-model/templates/model.ejs
@@ -8,6 +8,6 @@ const <%= defaultExport %> = require('<%= moduleName %>');
 
 Object.assign(module.exports, {
   <%_ propTypes.forEach(({ key, validator }) => { _%>
-  <%= key %>: <%= validator %>,
+  '<%= key %>': <%= validator %>,
   <%_ }) _%>
 });

--- a/test/fixtures/generated/application
+++ b/test/fixtures/generated/application
@@ -7,11 +7,11 @@ const visibilityPropTypes = require('../enums/visibilityPropTypes');
 const auditPropTypes = require('../../../common/v0/models/auditPropTypes');
 
 Object.assign(module.exports, {
-  guid: PropTypes.string.isRequired,
-  organization: PropTypes.shape(referencePropTypes).isRequired,
-  name: PropTypes.string.isRequired,
-  key: PropTypes.string.isRequired,
-  visibility: PropTypes.oneOf(visibilityPropTypes).isRequired,
-  description: PropTypes.string,
-  audit: PropTypes.shape(auditPropTypes).isRequired,
+  'guid': PropTypes.string.isRequired,
+  'organization': PropTypes.shape(referencePropTypes).isRequired,
+  'name': PropTypes.string.isRequired,
+  'key': PropTypes.string.isRequired,
+  'visibility': PropTypes.oneOf(visibilityPropTypes).isRequired,
+  'description': PropTypes.string,
+  'audit': PropTypes.shape(auditPropTypes).isRequired,
 });


### PR DESCRIPTION
I didn't expect a field name to include dashes: 
https://app.apibuilder.io/flow/brickftp/latest#model-file_copy_form