### PR TITLE
auth

### DIFF
--- a/src/generators/node_graphql/generators/schema/templates/schema.ejs
+++ b/src/generators/node_graphql/generators/schema/templates/schema.ejs
@@ -42,7 +42,7 @@ const schema = new GraphQLSchema({
         <%_ if (description != null) { _%>
           description: '<%= description %>',
         <%_ } _%>
-        resolve: (source, args) => {
+        resolve: (parent, args, context) => {
           const path = [
             <%_ pathParts.forEach(part => { _%>
               <%_ if (part[0] === ':') { _%>
@@ -66,7 +66,13 @@ const schema = new GraphQLSchema({
             });
           <%_ } _%>
 
-          return got(path, { json: true, query }).then(response => response.body)
+          return got(path, {
+            json: true,
+            query,
+            headers: {
+              authorization: context.headers.authorization
+            }
+          }).then(response => response.body);
         }
       },
     <% }) %>


### PR DESCRIPTION
We make the assumption that the context is the HTTP request. Using express-graphql, this is the default. Using apollo-server, it can be done like this:

```js
const server = new ApolloServer({
  schema,
  context: ({ req }) => req,
});
```