### PR TITLE
Remove node specific modules from SDK generator to be truly isomorphic

### DIFF
--- a/src/generators/js_isomorphic/codegen/templates/client.hbs
+++ b/src/generators/js_isomorphic/codegen/templates/client.hbs
@@ -12,70 +12,6 @@ if (process.browser) {
   fetch = require('node-fetch'); // eslint-disable-line global-require
 }
 
-/**
- * Random string generator based on this article:
- * https://benjaminjurke.com/content/articles/2015/java-script-random-string-generator/
- */
-
-let seed = [
-  ((new Date()).getTime() * 41 ^ (Math.random() * Math.pow(2, 32))) >>> 0,
-  ((new Date()).getTime() * 41 ^ (Math.random() * Math.pow(2, 32))) >>> 0,
-  ((new Date()).getTime() * 41 ^ (Math.random() * Math.pow(2, 32))) >>> 0,
-  ((new Date()).getTime() * 41 ^ (Math.random() * Math.pow(2, 32))) >>> 0,
-];
-
-function addRandomSeed() {
-  const x = Math.floor(Math.random() * 1920);
-  const y = Math.floor(Math.random() * 1080);
-
-  seed[0] = ((seed[3] * 37)
-    ^ (new Date()).getTime() * 41
-    ^ Math.floor(Math.random() * Math.pow(2, 32))
-    + x
-    + y * 17) >>> 0;
-
-  seed[1] = ((seed[0] * 31)
-    ^ (new Date()).getTime() * 43
-    ^ Math.floor(Math.random() * Math.pow(2, 32))
-    + x
-    + y * 19) >>> 0;
-
-  seed[2] = ((seed[1] * 29)
-    ^ (new Date()).getTime() * 47
-    ^ Math.floor(Math.random() * Math.pow(2, 32))
-    + x
-    + y * 23) >>> 0;
-
-  seed[3] = ((seed[2] * 23)
-    ^ (new Date()).getTime() * 51
-    ^ Math.floor(Math.random() * Math.pow(2, 32))
-    + x
-    + y * 29) >>> 0;
-}
-
-function unsignedRandom(maxval, index) {
-  return Math.abs((
-    Math.floor(Math.random() * Math.pow(2, 32))
-    ^ (seed[index % 4] >>> (index % 23)))
-    % (maxval + 1));
-}
-
-function randomString(length) {
-  const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-  const charsLength = chars.length;
-
-  let result = '';
-  let index;
-
-  addRandomSeed();
-
-  for (index = length; index > 0; --index) {
-    result += chars[unsignedRandom(charsLength - 1, index)];
-  }
-
-  return result;
-}
-
 export default class Client extends EventEmitter {
   static validateAuth(auth) {
     // string type === default to Basic auth.
@@ -91,6 +27,7 @@ export default class Client extends EventEmitter {
     }
 
     const validTypes = ['basic', 'bearer', 'jwt'];
+
     if (!validTypes.includes(auth.type)) {
       throw new Error('Auth type must be one of: basic, bearer, jwt');
     }
@@ -177,12 +114,10 @@ export default class Client extends EventEmitter {
   makeRequest(url, opts = {}) {
     const startTimeMs = new Date().getTime();
     const finalUrl = Client.getFinalUrl(url, opts);
-    const requestId = randomString(20);
     const headers = this.calculateFinalHeaders(opts);
     const body = opts.body && typeof opts.body !== 'string' ? JSON.stringify(opts.body) : opts.body;
     const options = {
       credentials: 'same-origin',
-      requestId,
       ...opts,
       headers,
       body,
@@ -199,7 +134,7 @@ export default class Client extends EventEmitter {
         response.text().then((text) => {
           let result = text;
 
-          this.logResponse({ status: response.status, body: result, requestId, time: roundTripMs });
+          this.logResponse({ status: response.status, body: result, time: roundTripMs });
 
           // Return JSON if text can parse as such
           try {

--- a/src/generators/js_isomorphic/codegen/templates/client.hbs
+++ b/src/generators/js_isomorphic/codegen/templates/client.hbs
@@ -1,14 +1,20 @@
 import EventEmitter from 'events';
 import querystring from 'querystring';
 
-/**
- * Use the right implementation of fetch depending on the execution environment
- */
 let fetch;
+let base64Encode;
 
+/**
+ * Use the right implementation depending on the execution environment.
+ *
+ * NOTE: Consumer is expected to polyfill the browser environment when
+ * implementation for btoa or fetch is not available.
+ */
 if (process.browser) {
   fetch = window.fetch;
+  base64Encode = window.btoa;
 } else {
+  base64Encode = value => new Buffer(value).toString('base64');
   fetch = require('node-fetch'); // eslint-disable-line global-require
 }
 
@@ -34,7 +40,7 @@ export default class Client extends EventEmitter {
   }
 
   static getBasicAuthHeaderValue(auth) {
-    return `Basic ${new Buffer(auth).toString('base64')}`;
+    return `Basic ${base64Encode(auth)}`;
   }
 
   static getFinalUrl(url, opts) {


### PR DESCRIPTION
Using `crypto` and `Buffer` forces consumer to shim these modules in browser environments. JavaScript bundlers do this today automatically at the cost of increasing the size of the file to be downloaded, which is not great for web performance. 

I'm dropping the request identifier because it provides zero value at the moment. It seems originally the team wanted to use this as a correlation identifier, but that should not be the concern for this generator. This is an implementation detail that cannot be derived from the API builder specifications. I also have my own reservations about introducing such feature as part of the generated client.

Using `dtoa` to base64 encode strings instead of forcing shim for `Buffer` in browser environments. Similarly to `fetch`, legacy browser environments will need to polyfill this implementation if not available.

> Yes, yes, `querystring` and `EventEmitter` are also node specific modules that must be shimmed. My main concern right now is that `crypto` and `Buffer` are bloating the JavaScript bundles in our applications unnecessarily.