### PR TITLE
Fix issue where field/union types resolve to external types unnecessarily

### DIFF
--- a/src/utilities/apibuilder/type/service.ts
+++ b/src/utilities/apibuilder/type/service.ts
@@ -4,16 +4,8 @@ import {
   ApiBuilderImport,
   ApiBuilderModel,
   ApiBuilderResource,
-  ApiBuilderType,
   ApiBuilderUnion,
 } from '.';
-
-function findTypeByName(types: ApiBuilderType[], name: string) {
-  return find(types, overSome([
-    matchesProperty('shortName', name),
-    matchesProperty('baseType', name),
-  ]));
-}
 
 const mapToEnumType = memoize((schema, service) => {
   return ApiBuilderEnum.fromSchema(schema, service);
@@ -144,16 +136,16 @@ export class ApiBuilderService {
     return this.schema.base_url;
   }
 
-  public findModelByName(name) {
-    return findTypeByName(this.models, name);
-  }
-
-  public findEnumByName(name) {
-    return findTypeByName(this.enums, name);
-  }
-
-  public findUnionByName(name) {
-    return findTypeByName(this.unions, name);
+  public findTypeByName(typeName: string) {
+    // By definition, a field or union type whose name is not fully qualified
+    // implies the type is defined internally, that is such type is not imported.
+    // Since internal types precede external types in the list of types held
+    // by this object, we can guarantee that searching for a type by name will
+    // honor this rule.
+    return find(this.types, overSome([
+      matchesProperty('shortName', typeName),
+      matchesProperty('baseType', typeName),
+    ]));
   }
 
   public toString() {

--- a/src/utilities/apibuilder/utilities/ast.ts
+++ b/src/utilities/apibuilder/utilities/ast.ts
@@ -1,5 +1,11 @@
 import invariant = require('invariant');
-import { ApiBuilderArray, ApiBuilderMap, ApiBuilderPrimitiveType, ApiBuilderType } from '../type';
+import {
+  ApiBuilderArray,
+  ApiBuilderMap,
+  ApiBuilderPrimitiveType,
+  ApiBuilderService,
+  ApiBuilderType,
+} from '../type';
 import {
   FullyQualifiedType,
   getNestedTypeName,
@@ -71,7 +77,7 @@ export function typeNameFromAst(ast: IAst): string {
  * @param {ApiBuilderService} service
  * @returns {ApiBuilderType}
  */
-export function typeFromAst(ast: IAst, service: any): ApiBuilderType {
+export function typeFromAst(ast: IAst, service: ApiBuilderService): ApiBuilderType {
   if (ast.name === Kind.MAP) {
     return new ApiBuilderMap(typeFromAst(ast.type, service));
   }
@@ -85,9 +91,7 @@ export function typeFromAst(ast: IAst, service: any): ApiBuilderType {
   }
 
   return (
-    service.findModelByName(ast.name) ||
-    service.findUnionByName(ast.name) ||
-    service.findEnumByName(ast.name) ||
+    service.findTypeByName(ast.name) ||
     invariant(false, `${ast.name} is not a type defined in ${String(service)} service.`)
   );
 }

--- a/src/utilities/apibuilder/utilities/schema.ts
+++ b/src/utilities/apibuilder/utilities/schema.ts
@@ -105,7 +105,7 @@ export function getNestedTypeName(type: string): string {
  * isPrimitiveTypeName("[com.bryzek.spec.v0.models.reference]");
  * // => false
  */
-export function isPrimitiveTypeName(type: string) {
+export function isPrimitiveTypeName(type: string): boolean {
   return includes(
     [
       Kind.BOOLEAN,
@@ -125,6 +125,10 @@ export function isPrimitiveTypeName(type: string) {
   );
 }
 
+export function isValidFullyQualifiedTypeName(typeName: string): boolean {
+  return getBaseTypeName(typeName).lastIndexOf('.') >= 0 || isPrimitiveTypeName(typeName);
+}
+
 export class FullyQualifiedType {
   public fullyQualifiedType: string;
 
@@ -140,8 +144,7 @@ export class FullyQualifiedType {
    */
   constructor(fullyQualifiedType: string) {
     invariant(
-      getBaseTypeName(fullyQualifiedType).lastIndexOf('.') >= 0 ||
-      isPrimitiveTypeName(fullyQualifiedType),
+      isValidFullyQualifiedTypeName(fullyQualifiedType),
       `"${fullyQualifiedType}" is not fully qualified type or primitive type. ` +
       'A fully qualified type consists of a package name followed by the ' +
       'base short name. (e.g. "com.bryzek.apidoc.common.v0.models.reference").',

--- a/test/specs/generators/node_graphql/generators/model.spec.js
+++ b/test/specs/generators/node_graphql/generators/model.spec.js
@@ -6,7 +6,7 @@ const schema = require('../../../../fixtures/schemas/apidoc-api.json');
 const service = new ApiBuilderService({ service: schema });
 
 test('should generate GraphQL object type from API builder model', () => {
-  const model = service.findModelByName('application');
+  const model = service.findTypeByName('application');
   const file = generateFile(model);
   expect(file.name).toEqual('Application.js');
   expect(file.dir).toEqual('com/bryzek/apidoc/api/v0/models');

--- a/test/specs/generators/node_graphql/generators/union.spec.js
+++ b/test/specs/generators/node_graphql/generators/union.spec.js
@@ -6,7 +6,7 @@ const schema = require('../../../../fixtures/schemas/apidoc-api.json');
 const service = new ApiBuilderService({ service: schema });
 
 test('should generate GraphQL union type from API Builder union', () => {
-  const union = service.findUnionByName('diff');
+  const union = service.findTypeByName('diff');
   const file = generateFile(union);
   expect(file.name).toBe('Diff.js');
   expect(file.dir).toBe('com/bryzek/apidoc/api/v0/unions');

--- a/test/specs/generators/prop_types/generators/generator-model.spec.js
+++ b/test/specs/generators/prop_types/generators/generator-model.spec.js
@@ -8,11 +8,11 @@ const apidocService = new ApiBuilderService({ service: apidocSchema });
 const peopleService = new ApiBuilderService({ service: peopleSchema });
 
 test('should generate prop types for model types', () => {
-  const model = apidocService.findModelByName('application');
+  const model = apidocService.findTypeByName('application');
   expect(generateModel(model)).toEqual(loadFixture('./generated/prop_types/application'));
 });
 
 test('should generate prop types for models with cyclic dependencies', () => {
-  const model = peopleService.findModelByName('organization');
+  const model = peopleService.findTypeByName('organization');
   expect(generateModel(model)).toEqual(loadFixture('./generated/prop_types/organization'));
 });

--- a/test/specs/generators/prop_types/generators/generator-union.spec.js
+++ b/test/specs/generators/prop_types/generators/generator-union.spec.js
@@ -8,11 +8,11 @@ const apidocService = new ApiBuilderService({ service: apidocSchema });
 const peopleService = new ApiBuilderService({ service: peopleSchema });
 
 test('should generate prop types for union types', () => {
-  const union = apidocService.findUnionByName('diff');
+  const union = apidocService.findTypeByName('diff');
   expect(generateUnion(union)).toEqual(loadFixture('./generated/prop_types/diff'));
 });
 
 test('should generate prop types for union types with cyclic dependencies', () => {
-  const union = peopleService.findUnionByName('funder');
+  const union = peopleService.findTypeByName('funder');
   expect(generateUnion(union)).toEqual(loadFixture('./generated/prop_types/funder'));
 });

--- a/test/specs/generators/prop_types/utilities/isCyclic.spec.js
+++ b/test/specs/generators/prop_types/utilities/isCyclic.spec.js
@@ -7,73 +7,73 @@ const peopleService = new ApiBuilderService({ service: peopleApiSchema });
 describe('isCyclic', () => {
   test('should return true for self-references', () => {
     expect(isCyclic(
-      peopleService.findModelByName('person'),
-      peopleService.findModelByName('person'),
+      peopleService.findTypeByName('person'),
+      peopleService.findTypeByName('person'),
     )).toBe(true);
   });
 
   test('should return true when target model contains some field that references the same type as the source', () => {
     expect(isCyclic(
-      peopleService.findModelByName('person'),
+      peopleService.findTypeByName('person'),
       // "person_detail" has an optional "person" field
-      peopleService.findModelByName('person_detail'),
+      peopleService.findTypeByName('person_detail'),
     )).toBe(true);
   });
 
   test('should return true when target model contains some field that deeply references the same type as the source', () => {
     expect(isCyclic(
-      peopleService.findEnumByName('gender'),
+      peopleService.findTypeByName('gender'),
       // "employee" model has an optional "person" field
       // "person" model has a "gender" field
-      peopleService.findModelByName('employee'),
+      peopleService.findTypeByName('employee'),
     )).toBe(true);
   });
 
   test('should return true when target union contains some union type that is the same type as the source', () => {
     expect(isCyclic(
-      peopleService.findModelByName('organization'),
+      peopleService.findTypeByName('organization'),
       // "funder" union can be either an "organization" or "person" model
-      peopleService.findUnionByName('funder'),
+      peopleService.findTypeByName('funder'),
     )).toBe(true);
   });
 
   test('should return true when target union contains some union type that deeply references the same type as the source', () => {
     expect(isCyclic(
-      peopleService.findEnumByName('gender'),
+      peopleService.findTypeByName('gender'),
       // "funder" is an union that can be either an "organization" or "person" type
       // both models deeply reference the "gender" enum
       // "organization" is a model that has a field of type "[employee]"
       // "employee" is a model that has a field of type "person"
       // "person" is a model that has a field of type "gender"
-      peopleService.findUnionByName('funder'),
+      peopleService.findTypeByName('funder'),
     )).toBe(true);
   });
 
   test('should return false when source is a primitive type', () => {
     expect(isCyclic(
       new ApiBuilderPrimitiveType(new FullyQualifiedType('string')),
-      peopleService.findModelByName('person'),
+      peopleService.findTypeByName('person'),
     )).toBe(false);
   });
 
   test('should return false when target is a primitive type', () => {
     expect(isCyclic(
-      peopleService.findModelByName('person'),
+      peopleService.findTypeByName('person'),
       new ApiBuilderPrimitiveType(new FullyQualifiedType('string')),
     )).toBe(false);
   });
 
   test('should return false when target is a model with fields that do not reference source type', () => {
     expect(isCyclic(
-      peopleService.findEnumByName('gender'),
-      peopleService.findModelByName('postal_address'),
+      peopleService.findTypeByName('gender'),
+      peopleService.findTypeByName('postal_address'),
     )).toBe(false);
   });
 
   test('should return false when target is an union with union types that do not reference source type', () => {
     expect(isCyclic(
-      peopleService.findModelByName('person'),
-      peopleService.findUnionByName('address_country'),
+      peopleService.findTypeByName('person'),
+      peopleService.findTypeByName('address_country'),
     )).toBe(false);
   });
 });

--- a/test/specs/generators/prop_types/utilities/toDefaultExport.spec.js
+++ b/test/specs/generators/prop_types/utilities/toDefaultExport.spec.js
@@ -6,17 +6,17 @@ const service = new ApiBuilderService({ service: schema });
 
 describe('toDefaultExport', () => {
   test('should return default export name for enum', () => {
-    const enumeration = service.findEnumByName('original_type');
+    const enumeration = service.findTypeByName('original_type');
     expect(toDefaultExport(enumeration)).toBe('originalType');
   });
 
   test('should return default export name for model', () => {
-    const model = service.findModelByName('attribute_value_form');
+    const model = service.findTypeByName('attribute_value_form');
     expect(toDefaultExport(model)).toBe('attributeValueForm');
   });
 
   test('should return default export name for union', () => {
-    const union = service.findUnionByName('item_detail');
+    const union = service.findTypeByName('item_detail');
     expect(toDefaultExport(union)).toBe('itemDetail');
   });
 


### PR DESCRIPTION
@benwaffle is not possible to compute the FQN for fields because it's not possible to guess its type without looking it up in the service anyways, so went with this approach.