### PR TITLE
Add Content-Type to client logResponse

### DIFF
--- a/src/generators/js_isomorphic/codegen/templates/client.hbs
+++ b/src/generators/js_isomorphic/codegen/templates/client.hbs
@@ -140,7 +140,12 @@ export default class Client extends EventEmitter {
         response.text().then((text) => {
           let result = text;
 
-          this.logResponse({ status: response.status, body: result, time: roundTripMs });
+          this.logResponse({
+            status: response.status,
+            body: result,
+            time: roundTripMs,
+            type: response.headers.get('content-type'),
+          });
 
           // Return JSON if text can parse as such
           try {


### PR DESCRIPTION
Add Content-type as `type` to logResponse call to determine handling of response body (i.e. parse if application/json)