### PR TITLE
openapi: use any type for imported models

### DIFF
--- a/src/generators/openapi/generators/openapi-operation/generateOperationObject.ts
+++ b/src/generators/openapi/generators/openapi-operation/generateOperationObject.ts
@@ -10,6 +10,7 @@ import {
 import { generateParameterObject } from '../openapi-parameter';
 import { generateRequestBodyObject } from '../openapi-request-body';
 import { generateResponsesObject } from '../openapi-responses';
+import { isTypeImported } from '../openapi-utils';
 
 function generateOperationObject(
   apibuilderOperation: ApiBuilderOperation,
@@ -27,12 +28,12 @@ function generateOperationObject(
   };
 
   const generateParameterObjectWithValidation = (parameter) => {
-    return generateParameterObject(parameter, typeValidator);
+    return generateParameterObject(parameter, typeValidator, isTypeImported(service));
   };
 
   const generateRequestBodyObjectWithValidation = (body: ApiBuilderBody)
   : RequestBodyObject => {
-    return generateRequestBodyObject(body, typeValidator);
+    return generateRequestBodyObject(body, typeValidator, isTypeImported(service));
   };
 
   return {

--- a/src/generators/openapi/generators/openapi-parameter/generateParameterObject.ts
+++ b/src/generators/openapi/generators/openapi-parameter/generateParameterObject.ts
@@ -8,10 +8,12 @@ import {
   convertApiBuilderType,
   convertLocationToIn,
 } from '../openapi-utils';
+import { IsImportedChecker } from '../openapi-utils/isTypeImported';
 
 function generateParameterObject(
   apibuilderParameter: ApiBuilderParameter,
   parameterTypeValidator,
+  isImported: IsImportedChecker,
 ): ParameterObject {
   const {
     defaultValue,
@@ -39,7 +41,7 @@ Apibuilder defined this parameter location as "Form" which is incompatible with 
     example: defaultValue ? defaultValue : undefined,
     in: convertLocationToIn(location as ApiBuilderParameterLocation),
     required: isRequired,
-    schema: convertApiBuilderType(type, parameterTypeValidator),
+    schema: convertApiBuilderType(type, parameterTypeValidator, isImported),
     ...shorthand,
   };
 

--- a/src/generators/openapi/generators/openapi-request-body/generateRequestBodyObject.ts
+++ b/src/generators/openapi/generators/openapi-request-body/generateRequestBodyObject.ts
@@ -1,8 +1,13 @@
 import { RequestBodyObject } from '@loopback/openapi-v3-types';
 import { ApiBuilderBody } from 'apibuilder-js';
 import { convertApiBuilderType } from '../openapi-utils';
+import { IsImportedChecker } from '../openapi-utils/isTypeImported';
 
-function generateRequestBodyObject(apibuilderBody: ApiBuilderBody, validator): RequestBodyObject {
+function generateRequestBodyObject(
+  apibuilderBody: ApiBuilderBody,
+  validator,
+  isImported: IsImportedChecker,
+): RequestBodyObject {
   const {
     type,
   } = apibuilderBody;
@@ -10,7 +15,7 @@ function generateRequestBodyObject(apibuilderBody: ApiBuilderBody, validator): R
   return {
     content: {
       'application/json': {
-        schema: convertApiBuilderType(type, validator),
+        schema: convertApiBuilderType(type, validator, isImported),
       },
     },
   };

--- a/src/generators/openapi/generators/openapi-schemas/generateSchemaFromModel.ts
+++ b/src/generators/openapi/generators/openapi-schemas/generateSchemaFromModel.ts
@@ -6,10 +6,17 @@ import {
 import {
   generateSchemaPropertiesFromModelFields,
 } from '../openapi-schemas';
+import { IsImportedChecker } from '../openapi-utils/isTypeImported';
 
-function generateSchemaFromModel(model: ApiBuilderModel, modelValidator) {
+function generateSchemaFromModel(
+  model: ApiBuilderModel,
+  modelValidator,
+  isImported: IsImportedChecker,
+) {
   const required = map(filter(model.fields, ['required', true]), req => req.name);
-  const properties = generateSchemaPropertiesFromModelFields(model.fields, modelValidator);
+  const properties = generateSchemaPropertiesFromModelFields(model.fields,
+                                                             modelValidator,
+                                                             isImported);
 
   return {
     [model.shortName]: {

--- a/src/generators/openapi/generators/openapi-schemas/generateSchemaFromUnion.ts
+++ b/src/generators/openapi/generators/openapi-schemas/generateSchemaFromUnion.ts
@@ -2,10 +2,15 @@ import { SchemaObject } from '@loopback/openapi-v3-types';
 import { ApiBuilderUnion } from 'apibuilder-js';
 import { map } from 'lodash';
 import { convertApiBuilderType } from '../openapi-utils';
+import { IsImportedChecker } from '../openapi-utils/isTypeImported';
 
-function generateSchemaFromUnion(union: ApiBuilderUnion, typeValidation): SchemaObject {
+function generateSchemaFromUnion(
+  union: ApiBuilderUnion,
+  typeValidation,
+  isImported: IsImportedChecker,
+): SchemaObject {
   const types = map(union.types, t => t.type);
-  const unionTypes = map(types, t => convertApiBuilderType(t, typeValidation));
+  const unionTypes = map(types, t => convertApiBuilderType(t, typeValidation, isImported));
   return {
     [union.name]: {
       ...union.description && { description:  union.description },

--- a/src/generators/openapi/generators/openapi-schemas/generateSchemaModels.ts
+++ b/src/generators/openapi/generators/openapi-schemas/generateSchemaModels.ts
@@ -1,10 +1,11 @@
 import { map } from 'lodash';
-import { typeValidator } from '../openapi-utils';
+import { isTypeImported, typeValidator } from '../openapi-utils';
 import generateSchemaFromModel from './generateSchemaFromModel';
 
 function generateSchemaModels(service) {
   const validator = typeValidator(service);
-  return map(service.models, model => generateSchemaFromModel(model, validator));
+  const isImported = isTypeImported(service);
+  return map(service.models, model => generateSchemaFromModel(model, validator, isImported));
 }
 
 export default generateSchemaModels;

--- a/src/generators/openapi/generators/openapi-schemas/generateSchemaPropertiesFromModelFields.ts
+++ b/src/generators/openapi/generators/openapi-schemas/generateSchemaPropertiesFromModelFields.ts
@@ -1,12 +1,17 @@
 import { ApiBuilderField } from 'apibuilder-js';
 import { reduce } from 'lodash';
 import { convertApiBuilderType } from '../openapi-utils';
+import { IsImportedChecker } from '../openapi-utils/isTypeImported';
 
-function generateSchemaPropertiesFromModelFields(fields: ApiBuilderField[], validate) {
+function generateSchemaPropertiesFromModelFields(
+  fields: ApiBuilderField[],
+  validate,
+  isImported: IsImportedChecker,
+) {
   return reduce(
     fields,
     (acc, value) => {
-      acc[value.name] = convertApiBuilderType(value.type, validate);
+      acc[value.name] = convertApiBuilderType(value.type, validate, isImported);
       return acc;
     },
     {},

--- a/src/generators/openapi/generators/openapi-schemas/generateSchemaUnions.ts
+++ b/src/generators/openapi/generators/openapi-schemas/generateSchemaUnions.ts
@@ -2,11 +2,12 @@ import { SchemaObject } from '@loopback/openapi-v3-types';
 import { ApiBuilderService } from 'apibuilder-js';
 import { map } from 'lodash';
 import { generateSchemaFromUnion } from '../openapi-schemas';
-import { typeValidator } from '../openapi-utils';
+import { isTypeImported, typeValidator } from '../openapi-utils';
 
 function generateSchemaUnions(service: ApiBuilderService): SchemaObject[] {
   const typeValidation = typeValidator(service);
-  return map(service.unions, union => generateSchemaFromUnion(union, typeValidation));
+  return map(service.unions, union =>
+    generateSchemaFromUnion(union, typeValidation, isTypeImported(service)));
 }
 
 export default generateSchemaUnions;

--- a/src/generators/openapi/generators/openapi-utils/convertApiBuilderArray.ts
+++ b/src/generators/openapi/generators/openapi-utils/convertApiBuilderArray.ts
@@ -1,10 +1,16 @@
+import { SchemaObject } from '@loopback/openapi-v3-types';
 import { ApiBuilderArray } from 'apibuilder-js';
 import { convertApiBuilderType } from '../openapi-utils';
+import { IsImportedChecker } from './isTypeImported';
 
-function convertApiBuilderArray(array: ApiBuilderArray, validate) {
+function convertApiBuilderArray(
+  array: ApiBuilderArray,
+  validate,
+  isImported: IsImportedChecker,
+): SchemaObject {
   const type = array.ofType;
   return {
-    items: convertApiBuilderType(type, validate),
+    items: convertApiBuilderType(type, validate, isImported),
     type: 'array',
   };
 }

--- a/src/generators/openapi/generators/openapi-utils/convertApiBuilderPrimitiveType.ts
+++ b/src/generators/openapi/generators/openapi-utils/convertApiBuilderPrimitiveType.ts
@@ -1,9 +1,10 @@
+import { SchemaObject } from '@loopback/openapi-v3-types';
 import {
   ApiBuilderPrimitiveType,
   Kind,
  } from 'apibuilder-js';
 
-function convertApiBuilderPrimitiveType(type: ApiBuilderPrimitiveType) {
+function convertApiBuilderPrimitiveType(type: ApiBuilderPrimitiveType): SchemaObject {
   switch (type.baseTypeName) {
     case Kind.BOOLEAN: return { type: 'boolean' };
     case Kind.DATE_ISO8601: return { type: 'string', format: 'date' };

--- a/src/generators/openapi/generators/openapi-utils/convertApiBuilderType.ts
+++ b/src/generators/openapi/generators/openapi-utils/convertApiBuilderType.ts
@@ -1,3 +1,4 @@
+import { SchemaObject } from '@loopback/openapi-v3-types';
 import {
   ApiBuilderArray,
   ApiBuilderEnum,
@@ -11,20 +12,30 @@ import {
   convertApiBuilderPrimitiveType,
   convertApiBuilderTypeToReference,
 } from '../openapi-utils';
+import { IsImportedChecker } from './isTypeImported';
 
-function convertApiBuilderType(type: ApiBuilderType, validate) {
+function convertApiBuilderType(
+  type: ApiBuilderType,
+  validate,
+  isImported: IsImportedChecker,
+): SchemaObject {
   if (type instanceof ApiBuilderPrimitiveType) {
     return convertApiBuilderPrimitiveType(type);
   }
 
   if (type instanceof ApiBuilderArray) {
-    return convertApiBuilderArray(type, validate);
+    return convertApiBuilderArray(type, validate, isImported);
   }
 
   if (
     type instanceof ApiBuilderModel ||
     type instanceof ApiBuilderEnum ||
     type instanceof ApiBuilderUnion) {
+
+    if (isImported(type)) {
+      return {}; // any type
+    }
+
     if (validate(type)) {
       return convertApiBuilderTypeToReference(type);
     }

--- a/src/generators/openapi/generators/openapi-utils/index.ts
+++ b/src/generators/openapi/generators/openapi-utils/index.ts
@@ -4,6 +4,5 @@ export { default as convertApiBuilderPrimitiveType } from './convertApiBuilderPr
 export { default as convertApiBuilderArray } from './convertApiBuilderArray';
 export { default as convertApiBuilderTypeToReference } from './convertApiBuilderTypeToReference';
 export { default as convertLocationToIn } from './convertLocationToIn';
-export {
-  default as extractApiBuilderResourceOperations,
-} from './extractApiBuilderResourceOperations';
+export { default as extractApiBuilderResourceOperations } from './extractApiBuilderResourceOperations';
+export { default as isTypeImported } from './isTypeImported';

--- a/src/generators/openapi/generators/openapi-utils/isTypeImported.ts
+++ b/src/generators/openapi/generators/openapi-utils/isTypeImported.ts
@@ -1,0 +1,10 @@
+import { ApiBuilderEnum, ApiBuilderModel, ApiBuilderService, ApiBuilderUnion } from 'apibuilder-js';
+
+export type IsImportedChecker =
+  (type: ApiBuilderModel | ApiBuilderUnion | ApiBuilderEnum) => boolean;
+
+export default function isTypeImported(service: ApiBuilderService): IsImportedChecker {
+  return (type: ApiBuilderModel | ApiBuilderUnion | ApiBuilderEnum) => {
+    return type.packageName !== service.namespace;
+  };
+}

--- a/src/generators/openapi/generators/openapi-utils/isTypeImported.ts
+++ b/src/generators/openapi/generators/openapi-utils/isTypeImported.ts
@@ -5,6 +5,7 @@ export type IsImportedChecker =
 
 export default function isTypeImported(service: ApiBuilderService): IsImportedChecker {
   return (type: ApiBuilderModel | ApiBuilderUnion | ApiBuilderEnum) => {
-    return type.packageName !== service.namespace;
+    const lastDot = type.packageName.lastIndexOf('.');
+    return type.packageName.substring(0, lastDot) !== service.namespace;
   };
 }

--- a/test/specs/generators/openapi/generators/generateSchemaModels.spec.ts
+++ b/test/specs/generators/openapi/generators/generateSchemaModels.spec.ts
@@ -5,6 +5,7 @@ import {
   generateSchemaModels,
 } from '../../../../../src/generators/openapi/generators/openapi-schemas';
 import apidocApiJson = require('../../../../fixtures/schemas/apidoc-api.json');
+import { isTypeImported } from '../../../../../src/generators/openapi/generators/openapi-utils';
 
 describe('generate schema models', () => {
   const service = new ApiBuilderService(apidocApiJson);

--- a/test/specs/generators/openapi/generators/generateSchemaModels.spec.ts
+++ b/test/specs/generators/openapi/generators/generateSchemaModels.spec.ts
@@ -1,0 +1,17 @@
+import {
+  ApiBuilderService,
+} from 'apibuilder-js';
+import {
+  generateSchemaModels,
+} from '../../../../../src/generators/openapi/generators/openapi-schemas';
+import apidocApiJson = require('../../../../fixtures/schemas/apidoc-api.json');
+
+describe('generate schema models', () => {
+  const service = new ApiBuilderService(apidocApiJson);
+  const schemaModels = generateSchemaModels(service);
+
+  test('should return object for imported models', () => {
+    const schema = schemaModels.find(models => models.application != null);
+    expect(schema.application.properties['organization']).toEqual({});
+  });
+});

--- a/test/specs/generators/openapi/generators/isImported.spec.ts
+++ b/test/specs/generators/openapi/generators/isImported.spec.ts
@@ -1,0 +1,15 @@
+import {
+  ApiBuilderService,
+} from 'apibuilder-js';
+import apidocApiJson = require('../../../../fixtures/schemas/apidoc-api.json');
+import { isTypeImported } from '../../../../../src/generators/openapi/generators/openapi-utils';
+
+describe('service', () => {
+  const service = new ApiBuilderService(apidocApiJson);
+
+  test('should check if types are imported', () => {
+    const isImported = isTypeImported(service)
+    expect(isImported(service.findTypeByName('organization'))).toBeFalsy();
+    expect(isImported(service.findTypeByName('com.bryzek.apidoc.common.v0.models.audit'))).toBeTruthy();
+  });
+});


### PR DESCRIPTION
We cannot generate the schemas because the fields are not passed in the imports to the generator. Accept any type instead of a $ref