### PR TITLE
Add ability to filter generated type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1105,9 +1105,9 @@
       }
     },
     "apibuilder-js": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/apibuilder-js/-/apibuilder-js-0.0.13.tgz",
-      "integrity": "sha512-3kOa0ZJvPiTtmzJ3eU+4aAVHI8dHJGNuCM5iOokQD0StpputaRlDSEXcR9rtvvlgyP0N1g0BAYigunFSRP+vtg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/apibuilder-js/-/apibuilder-js-0.0.15.tgz",
+      "integrity": "sha512-YoqrVZrazNj1Je7lj0T9QLuaB2tuqvUMYAFo2hTsqI/Uywq/dVEGu9c309XOOiGfq64MjmpuPyhzDbar/UsK5w==",
       "requires": {
         "invariant": "^2.2.4",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@loopback/openapi-v3-types": "^1.2.1",
-    "apibuilder-js": "0.0.13",
+    "apibuilder-js": "0.0.15",
     "ast-types": "^0.13.4",
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -28,11 +28,15 @@ async function postInvocationForm(invocationForm, options = {}) {
     body: invocationForm,
   });
 
-  response.body.files.forEach((file) => {
-    const destinationPath = path.resolve(program.output, file.dir, file.name);
+  response.body.files.forEach(({
+    dir = '.',
+    name,
+    contents,
+  }) => {
+    const destinationPath = path.resolve(program.output, dir, name);
     log(`Writing to "${path.relative(process.cwd(), destinationPath)}"`);
     mkdirp.sync(path.dirname(destinationPath));
-    fs.writeFileSync(destinationPath, file.contents);
+    fs.writeFileSync(destinationPath, contents);
   });
 }
 

--- a/src/builders/context.ts
+++ b/src/builders/context.ts
@@ -224,15 +224,26 @@ export function buildContext(
     typeName: string,
     predicate?: (typeName: string) => boolean,
   ) => {
-    collection.add(typeName);
-    const dependencies = dependencyRecord[typeName];
-    if (dependencies != null) {
-      dependencies.forEach((dependency) => {
-        if (typeof predicate !== 'function' || predicate(dependency)) {
-          addTypeWithDependencies(collection, dependency, predicate);
+    const visited: Record<string, boolean> = {};
+
+    function recurse(typeName) {
+      // To avoid infinite recursion due to cyclic types
+      if (!visited[typeName]) {
+        visited[typeName] = true;
+        collection.add(typeName);
+        const dependencies = dependencyRecord[typeName];
+        if (dependencies != null) {
+          dependencies.forEach((dependency) => {
+            if (typeof predicate !== 'function' || predicate(dependency)) {
+              recurse(dependency);
+            }
+          });
         }
-      });
+      }
     }
+
+    recurse(typeName);
+
     return collection;
   };
 

--- a/src/builders/declaration.ts
+++ b/src/builders/declaration.ts
@@ -330,7 +330,11 @@ function buildModuleIdentifiers(
 function buildModuleDeclaration(
   identifiers: namedTypes.Identifier[],
   declarations: (namedTypes.TSInterfaceDeclaration | namedTypes.TSTypeAliasDeclaration)[],
-): namedTypes.TSModuleDeclaration {
+): namedTypes.TSModuleDeclaration | undefined {
+  if (!declarations.length) {
+    return undefined;
+  }
+
   function recurse(
     left: namedTypes.Identifier[],
     right: namedTypes.TSModuleDeclaration,
@@ -356,7 +360,7 @@ function buildModuleDeclaration(
 function buildEnumModuleDeclaration(
   service: ApiBuilderService,
   context: Context,
-): namedTypes.TSModuleDeclaration {
+): namedTypes.TSModuleDeclaration | undefined {
   const identifiers = buildModuleIdentifiers(service, 'enums');
   const declarations = service.enums
     .filter((_) => context.allowTypes.has(_.fullName))
@@ -367,7 +371,7 @@ function buildEnumModuleDeclaration(
 function buildModelModuleDeclaration(
   service: ApiBuilderService,
   context: Context,
-) {
+): namedTypes.TSModuleDeclaration | undefined {
   const identifiers = buildModuleIdentifiers(service, 'models');
   const declarations = service.models
     .filter((_) => context.allowTypes.has(_.fullName))
@@ -378,7 +382,7 @@ function buildModelModuleDeclaration(
 function buildUnionModuleDeclaration(
   service: ApiBuilderService,
   context: Context,
-) {
+): namedTypes.TSModuleDeclaration | undefined {
   const identifiers = buildModuleIdentifiers(service, 'unions');
   const declarations = service.unions
     .filter((_) => context.allowTypes.has(_.fullName))
@@ -393,15 +397,24 @@ export function buildModuleDeclarationsFromService(
   const modules: namedTypes.TSModuleDeclaration[] = [];
 
   if (service.enums.length) {
-    modules.push(buildEnumModuleDeclaration(service, context));
+    const module = buildEnumModuleDeclaration(service, context);
+    if (module != null) {
+      modules.push(module);
+    }
   }
 
   if (service.models.length) {
-    modules.push(buildModelModuleDeclaration(service, context));
+    const module = buildModelModuleDeclaration(service, context);
+    if (module != null) {
+      modules.push(module);
+    }
   }
 
   if (service.unions.length) {
-    modules.push(buildUnionModuleDeclaration(service, context));
+    const module = buildUnionModuleDeclaration(service, context);
+    if (module != null) {
+      modules.push(module);
+    }
   }
 
   return modules;

--- a/src/builders/declaration.ts
+++ b/src/builders/declaration.ts
@@ -355,10 +355,12 @@ function buildModuleDeclaration(
 
 function buildEnumModuleDeclaration(
   service: ApiBuilderService,
+  context: Context,
 ): namedTypes.TSModuleDeclaration {
   const identifiers = buildModuleIdentifiers(service, 'enums');
   const declarations = service.enums
-    .map(enumeration => buildEnumTypeAliasDeclaration(enumeration));
+    .filter((_) => context.allowTypes.has(_.fullName))
+    .map(_ => buildEnumTypeAliasDeclaration(_));
   return buildModuleDeclaration(identifiers, declarations);
 }
 
@@ -368,7 +370,8 @@ function buildModelModuleDeclaration(
 ) {
   const identifiers = buildModuleIdentifiers(service, 'models');
   const declarations = service.models
-    .map(model => buildModelInterfaceDeclaration(model, context));
+    .filter((_) => context.allowTypes.has(_.fullName))
+    .map((_) => buildModelInterfaceDeclaration(_, context));
   return buildModuleDeclaration(identifiers, declarations);
 }
 
@@ -378,7 +381,8 @@ function buildUnionModuleDeclaration(
 ) {
   const identifiers = buildModuleIdentifiers(service, 'unions');
   const declarations = service.unions
-    .map(union => buildUnionTypeAliasDeclaration(union, context));
+    .filter((_) => context.allowTypes.has(_.fullName))
+    .map((_) => buildUnionTypeAliasDeclaration(_, context));
   return buildModuleDeclaration(identifiers, declarations);
 }
 
@@ -389,7 +393,7 @@ export function buildModuleDeclarationsFromService(
   const modules: namedTypes.TSModuleDeclaration[] = [];
 
   if (service.enums.length) {
-    modules.push(buildEnumModuleDeclaration(service));
+    modules.push(buildEnumModuleDeclaration(service, context));
   }
 
   if (service.models.length) {

--- a/src/builders/types.ts
+++ b/src/builders/types.ts
@@ -7,8 +7,14 @@ import {
 
 export type TypeRecord = Record<string, (ApiBuilderEnum | ApiBuilderModel | ApiBuilderUnion)>;
 
+export type DependencyRecord = Record<string, Set<string>>;
+
 // tslint:disable-next-line: interface-name
 export interface Context {
+  /**
+   * Types that can be generated.
+   */
+  allowTypes: Set<string>;
   /**
    * This property holds types indexed by their fully qualified name.
    */

--- a/src/utilities/getTags.ts
+++ b/src/utilities/getTags.ts
@@ -1,0 +1,14 @@
+import type { ApiBuilderEnum, ApiBuilderModel, ApiBuilderUnion } from 'apibuilder-js';
+import isArrayOfString from './isArrayOfStrings';
+
+type Tags = string[];
+
+export default function getTags(
+  type: ApiBuilderEnum | ApiBuilderModel | ApiBuilderUnion
+): Tags {
+  return type.attributes.reduce<Tags>((tags, attribute) => {
+    if (attribute.name === 'tags' && isArrayOfString(attribute.value))
+      tags.push(...attribute.value);
+    return tags;
+  }, []);
+}

--- a/src/utilities/isArrayOfStrings.ts
+++ b/src/utilities/isArrayOfStrings.ts
@@ -1,0 +1,3 @@
+export default function isArrayOfString(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((_) => typeof _ === 'string');
+}


### PR DESCRIPTION
Adds ability to filter type declarations to be generated using "tags".

Note that "tags" are represented using a custom attribute, e.g.:

Given a model is defined with the following custom attribute:

```json
{
  "name": "my_model",
  "attributes": [
    { "name": "tags", "value": ["@mytag"] }
  ],
}
```

The `allow_tags` attribute can be used in your `.apibuilder/config` file to indicate to the generator that only types with the specified tags should be generated:

```yaml
code:
  acme:
    api:
      version: latest
      generators:
        ts_declarations_v2: 
          target: "src/generated"
          attributes:
            allow_tags: "@mytag"
```

You can also specify multiple tags using a comma separated list (e.g. `"@tag1,@tag2,@tag3"`).